### PR TITLE
Made genetic working only with heads of inseparable chains

### DIFF
--- a/sampo/scheduler/genetic/base.py
+++ b/sampo/scheduler/genetic/base.py
@@ -89,7 +89,7 @@ class GeneticScheduler(Scheduler):
             -> tuple[Schedule, Time, Timeline]:
         def init_schedule(scheduler_class):
             return (scheduler_class(work_estimator=self.work_estimator).schedule(wg, contractors),
-                    prioritization(wg, self.work_estimator))
+                    list(reversed(prioritization(wg, self.work_estimator))))
 
         init_schedules: Dict[str, tuple[Schedule, list[GraphNode] | None]] = {
             "heft_end": init_schedule(HEFTScheduler),

--- a/sampo/scheduler/genetic/base.py
+++ b/sampo/scheduler/genetic/base.py
@@ -4,11 +4,12 @@ from typing import Dict, List, Tuple, Optional
 from sampo.scheduler.base import Scheduler, SchedulerType
 from sampo.scheduler.genetic.schedule_builder import build_schedule
 from sampo.scheduler.heft.base import HEFTScheduler
+from sampo.scheduler.heft.prioritization import prioritization
 from sampo.scheduler.heft_between.base import HEFTBetweenScheduler
 from sampo.scheduler.resource.identity import IdentityResourceOptimizer
 from sampo.scheduler.timeline.base import Timeline
 from sampo.schemas.contractor import Contractor, get_worker_contractor_pool
-from sampo.schemas.graph import WorkGraph
+from sampo.schemas.graph import WorkGraph, GraphNode
 from sampo.schemas.schedule import Schedule
 from sampo.schemas.schedule_spec import ScheduleSpec
 from sampo.schemas.time import Time
@@ -87,9 +88,10 @@ class GeneticScheduler(Scheduler):
                             timeline: Timeline | None = None) \
             -> tuple[Schedule, Time, Timeline]:
         def init_schedule(scheduler_class):
-            return scheduler_class(work_estimator=self.work_estimator).schedule(wg, contractors)
+            return (scheduler_class(work_estimator=self.work_estimator).schedule(wg, contractors),
+                    prioritization(wg, self.work_estimator))
 
-        init_schedules: Dict[str, Schedule] = {
+        init_schedules: Dict[str, tuple[Schedule, list[GraphNode] | None]] = {
             "heft_end": init_schedule(HEFTScheduler),
             "heft_between": init_schedule(HEFTBetweenScheduler)
         }

--- a/sampo/scheduler/genetic/converter.py
+++ b/sampo/scheduler/genetic/converter.py
@@ -6,7 +6,7 @@ from sampo.scheduler.base import Scheduler
 from sampo.scheduler.timeline.base import Timeline
 from sampo.scheduler.timeline.just_in_time_timeline import JustInTimeTimeline
 from sampo.schemas.contractor import WorkerContractorPool, Contractor
-from sampo.schemas.graph import GraphNode
+from sampo.schemas.graph import GraphNode, WorkGraph
 from sampo.schemas.resources import Worker
 from sampo.schemas.schedule import ScheduledWork, Schedule
 from sampo.schemas.schedule_spec import ScheduleSpec
@@ -16,15 +16,15 @@ from sampo.schemas.time_estimator import WorkTimeEstimator
 ChromosomeType = Tuple[np.ndarray, np.ndarray, np.ndarray]
 
 
-def convert_schedule_to_chromosome(index2node: list[tuple[int, GraphNode]],
+def convert_schedule_to_chromosome(wg: WorkGraph,
                                    work_id2index: dict[str, int], worker_name2index: dict[str, int],
                                    contractor2index: dict[str, int], contractor_borders: np.ndarray,
                                    schedule: Schedule, order: list[GraphNode] | None = None) -> ChromosomeType:
     """
     Receive result of scheduling algorithm and transform it to chromosome
 
+    :param wg:
     :param work_id2index:
-    :param index2node:
     :param worker_name2index:
     :param contractor2index:
     :param contractor_borders:
@@ -33,7 +33,8 @@ def convert_schedule_to_chromosome(index2node: list[tuple[int, GraphNode]],
     :return:
     """
 
-    order: list[GraphNode] = order if order is not None else schedule.works
+    order: list[GraphNode] = order if order is not None else [work for work in schedule.works
+                                                              if not wg[work.work_unit.id].is_inseparable_son()]
 
     # order works part of chromosome
     order_chromosome: np.ndarray = np.array([work_id2index[work.work_unit.id] for work in order])

--- a/sampo/scheduler/genetic/converter.py
+++ b/sampo/scheduler/genetic/converter.py
@@ -19,7 +19,7 @@ ChromosomeType = Tuple[np.ndarray, np.ndarray, np.ndarray]
 def convert_schedule_to_chromosome(index2node: list[tuple[int, GraphNode]],
                                    work_id2index: dict[str, int], worker_name2index: dict[str, int],
                                    contractor2index: dict[str, int], contractor_borders: np.ndarray,
-                                   schedule: Schedule) -> ChromosomeType:
+                                   schedule: Schedule, order: list[GraphNode] | None = None) -> ChromosomeType:
     """
     Receive result of scheduling algorithm and transform it to chromosome
 
@@ -29,11 +29,14 @@ def convert_schedule_to_chromosome(index2node: list[tuple[int, GraphNode]],
     :param contractor2index:
     :param contractor_borders:
     :param schedule:
+    :param order: if passed, specifies the node order that should appear in the chromosome
     :return:
     """
 
+    order: list[GraphNode] = order if order is not None else schedule.works
+
     # order works part of chromosome
-    order_chromosome: np.ndarray = np.array([work_id2index[swork.work_unit.id] for swork in schedule.works])
+    order_chromosome: np.ndarray = np.array([work_id2index[work.work_unit.id] for work in order])
 
     # convert to convenient form
     schedule = schedule.to_schedule_work_dict
@@ -42,17 +45,18 @@ def convert_schedule_to_chromosome(index2node: list[tuple[int, GraphNode]],
     # +1 stores contractors line
     resource_chromosome = np.zeros((len(worker_name2index) + 1, len(order_chromosome)), dtype=int)
 
-    for index, node in index2node:
+    for node in order:
+        node_id = node.work_unit.id
+        index = work_id2index[node_id]
         # TODO Check that `node_reqs` is really need
         node_reqs = set([req.kind for req in node.work_unit.worker_reqs])
-        for resource in schedule[node.id].workers:
+        for resource in schedule[node_id].workers:
             if resource.name in node_reqs:
                 res_count = resource.count
                 res_index = worker_name2index[resource.name]
                 res_contractor = resource.contractor_id
-                work_index = work_id2index[node.id]
-                resource_chromosome[res_index, work_index] = res_count
-                resource_chromosome[-1, work_index] = contractor2index[res_contractor]
+                resource_chromosome[res_index, index] = res_count
+                resource_chromosome[-1, index] = contractor2index[res_contractor]
 
     resource_border_chromosome = np.copy(contractor_borders)
 

--- a/sampo/scheduler/topological/base.py
+++ b/sampo/scheduler/topological/base.py
@@ -139,6 +139,10 @@ class TopologicalScheduler(Scheduler):
 
             st, ft, contractor, best_worker_team = run_contractor_search(contractors, run_with_contractor)
 
+            inseparable_chain = node.get_inseparable_chain()
+            if inseparable_chain:
+                skipped_inseparable_children.update((ch.id for ch in inseparable_chain))
+
             # finish scheduling with time spec
             timeline.schedule(index, node, node2swork, best_worker_team, contractor,
                               st, work_spec.assigned_time, assigned_parent_time, work_estimator)

--- a/tests/full_scheduling_test.py
+++ b/tests/full_scheduling_test.py
@@ -12,6 +12,9 @@ def test_schedule_synthetic(setup_contractors):
     wg = graph_restructuring(wg, use_lag_edge_optimization=True)
 
     for scheduler_type in list(SchedulerType):
-        schedule = generate_schedule(scheduler_type, None, wg, setup_contractors, validate_schedule=True)
+        try:
+            schedule = generate_schedule(scheduler_type, None, wg, setup_contractors, validate_schedule=True)
+        except AssertionError as e:
+            raise AssertionError(f'Scheduler {scheduler_type} failed validation', e)
 
         assert schedule.execution_time != Time.inf(), f'Scheduling failed on {scheduler_type.name}'

--- a/tests/full_scheduling_test.py
+++ b/tests/full_scheduling_test.py
@@ -3,11 +3,13 @@ from sampo.generator.pipeline.types import SyntheticGraphType
 from sampo.scheduler.base import SchedulerType
 from sampo.scheduler.generate import generate_schedule
 from sampo.schemas.time import Time
+from sampo.structurator import graph_restructuring
 
 
 def test_schedule_synthetic(setup_contractors):
     ss = SimpleSynthetic(rand=231)
     wg = ss.work_graph(SyntheticGraphType.General, 100, 200)
+    wg = graph_restructuring(wg, use_lag_edge_optimization=True)
 
     for scheduler_type in list(SchedulerType):
         schedule = generate_schedule(scheduler_type, None, wg, setup_contractors, validate_schedule=True)

--- a/tests/scheduler/genetic/fixtures.py
+++ b/tests/scheduler/genetic/fixtures.py
@@ -1,4 +1,3 @@
-from operator import attrgetter
 from random import Random
 from typing import List, Dict, Tuple, Optional
 
@@ -52,36 +51,60 @@ def create_toolbox(wg: WorkGraph,
                    rand: Random,
                    spec: ScheduleSpec = ScheduleSpec(),
                    work_estimator: WorkTimeEstimator = None) -> Tuple[Toolbox, np.ndarray]:
-    # preparing access-optimized data structures
-    index2node: Dict[int, GraphNode] = {index: node for index, node in enumerate(wg.nodes)}
+    nodes = [node for node in wg.nodes if not node.is_inseparable_son()]
+
+    index2node: Dict[int, GraphNode] = {index: node for index, node in enumerate(nodes)}
     work_id2index: Dict[str, int] = {node.id: index for index, node in index2node.items()}
     worker_name2index = {worker_name: index for index, worker_name in enumerate(worker_pool)}
     index2contractor = {ind: contractor.id for ind, contractor in enumerate(contractors)}
     index2contractor_obj = {ind: contractor for ind, contractor in enumerate(contractors)}
     contractor2index = reverse_dictionary(index2contractor)
-    index2node_list = [(index, node) for index, node in index2node.items()]
+    index2node_list = [(index, node) for index, node in enumerate(nodes)]
     worker_pool_indices = {worker_name2index[worker_name]: {
         contractor2index[contractor_id]: worker for contractor_id, worker in workers_of_type.items()
     } for worker_name, workers_of_type in worker_pool.items()}
-    node_indices = list(index2node.keys())
+    node_indices = list(range(len(nodes)))
+
+    contractors_capacity = np.zeros((len(contractors), len(worker_pool)))
+    for w_ind, cont2worker in worker_pool_indices.items():
+        for c_ind, worker in cont2worker.items():
+            contractors_capacity[c_ind][w_ind] = worker.count
+
+    resources_border = np.zeros((2, len(worker_pool), len(index2node)))
+    resources_min_border = np.zeros((len(worker_pool)))
+    for work_index, node in index2node.items():
+        for req in node.work_unit.worker_reqs:
+            worker_index = worker_name2index[req.kind]
+            resources_border[0, worker_index, work_index] = req.min_count
+            resources_border[1, worker_index, work_index] = req.max_count
+            resources_min_border[worker_index] = max(resources_min_border[worker_index], req.min_count)
 
     contractor_borders = np.zeros((len(contractor2index), len(worker_name2index)), dtype=int)
     for ind, contractor in enumerate(contractors):
         for ind_worker, worker in enumerate(contractor.workers.values()):
             contractor_borders[ind, ind_worker] = worker.count
 
+    # construct inseparable_child -> inseparable_parent mapping
+    inseparable_parents = {}
+    for node in nodes:
+        for child in node.get_inseparable_chain_with_self():
+            inseparable_parents[child] = node
+
+    # here we aggregate information about relationships from the whole inseparable chain
+    children = {work_id2index[node.id]: [work_id2index[inseparable_parents[child].id]
+                                         for inseparable in node.get_inseparable_chain_with_self()
+                                         for child in inseparable.children]
+                for node in nodes}
+
+    parents = {work_id2index[node.id]: [] for node in nodes}
+    for node, node_children in children.items():
+        for child in node_children:
+            parents[child].append(node)
+
     init_chromosomes: Dict[str, ChromosomeType] = \
-        {name: convert_schedule_to_chromosome(index2node_list, work_id2index, worker_name2index,
+        {name: convert_schedule_to_chromosome(wg, work_id2index, worker_name2index,
                                               contractor2index, contractor_borders, schedule)
          for name, schedule in init_schedules.items()}
-
-    resources_border = np.zeros((2, len(worker_pool), len(index2node)))
-    for work_index, node in index2node.items():
-        for req in node.work_unit.worker_reqs:
-            worker_index = worker_name2index[req.kind]
-            resources_border[0, worker_index, work_index] = req.min_count
-            resources_border[1, worker_index, work_index] = \
-                min(req.max_count, max(list(map(attrgetter('count'), worker_pool[req.kind].values()))))
 
     return init_toolbox(wg,
                         contractors,
@@ -102,6 +125,7 @@ def create_toolbox(wg: WorkGraph,
                         contractor_borders,
                         node_indices,
                         index2node_list,
+                        parents,
                         Time(0),
                         work_estimator), resources_border
 


### PR DESCRIPTION
Now genetic receives the prioritization order directly from HEFTs. In general, genetic now can construct chromosome using external-given order.
Added lag_optimization to full_scheduling_test.
Also, Topological problems when lag_optimization is ON are now completely fixed.